### PR TITLE
make car cards actually wrap.

### DIFF
--- a/src/frontend/src/components/CarTable.vue
+++ b/src/frontend/src/components/CarTable.vue
@@ -10,7 +10,7 @@ import BlankIcon from './icons/BlankIcon.vue';
 <template>
   <Loading v-if="loading" />
   <div v-else>
-    <table class="table">
+    <table class="table whitespace-normal">
       <thead>
         <tr>
           <th scope="col" @click="changeSort('driver')">

--- a/src/frontend/src/components/CarTable.vue
+++ b/src/frontend/src/components/CarTable.vue
@@ -10,7 +10,7 @@ import BlankIcon from './icons/BlankIcon.vue';
 <template>
   <Loading v-if="loading" />
   <div v-else>
-    <table class="table whitespace-normal">
+    <table class="table">
       <thead>
         <tr>
           <th scope="col" @click="changeSort('driver')">

--- a/src/frontend/src/views/HomeView.vue
+++ b/src/frontend/src/views/HomeView.vue
@@ -112,7 +112,6 @@ export default defineComponent({
 
 .noOverflow > * {
   overflow: auto;
-  white-space: nowrap;
   text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
This makes the formatting a lot better for narrower screen sizes like on mobile. Instead of scrolling left and right on the card, it now wraps so it is longer vertially.

This is a purely css change so I don't think any testing needs to be done other than trying a whole bunch of different screen sizes.