### PR TITLE
remove overflow: scroll in body style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79-bookworm AS base
+FROM rust:bookworm AS base
 RUN apt update && apt install -y libpq-dev
 
 FROM base AS chef

--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -41,6 +41,5 @@ main {
 
 body {
   padding-top: 70px;
-  overflow: scroll;
 }
 </style>


### PR DESCRIPTION
Exactly what the title says.

Before:
<img width="1919" height="1090" alt="image" src="https://github.com/user-attachments/assets/3d5255fc-065d-4aaa-ba37-09999eeaa75e" />

After:
<img width="1919" height="1089" alt="image" src="https://github.com/user-attachments/assets/98fbe5aa-cc89-4383-afa2-fb089663782c" />
